### PR TITLE
Add support for enums modeled as `sealed abstract case class`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
+.bsp
 
 # Scala-IDE specific
 .scala_dependencies
@@ -23,3 +24,4 @@ project/plugins/project/
 
 # Mac
 .DS_Store
+

--- a/src/main/scala/com/evolutiongaming/json/PartialUpdater.scala
+++ b/src/main/scala/com/evolutiongaming/json/PartialUpdater.scala
@@ -65,13 +65,19 @@ object PartialUpdater {
       val symbol = t.typeSymbol
       require(symbol.isClass)
 
-      symbol.asClass match {
-        case x if x.isCaseClass && !x.isDerivedValueClass => CaseClass(t)
-        case x if x.isCaseClass && x.isDerivedValueClass =>
-          val innerArg = x.primaryConstructor.asMethod.paramLists.head.head
+      val c = symbol.asClass
+      if (c.isCaseClass) {
+        if (c.isDerivedValueClass) {
+          val innerArg = c.primaryConstructor.asMethod.paramLists.head.head
           val innerType = innerArg.typeSignature
           ValueClass(t, innerType)
-        case _ => Generic(t)
+        } else if (c.isAbstract) {
+          Generic(t)
+        } else {
+          CaseClass(t)
+        }
+      } else {
+        Generic(t)
       }
     }
   }

--- a/src/test/scala/com/evolutiongaming/json/PartialUpdaterSpec.scala
+++ b/src/test/scala/com/evolutiongaming/json/PartialUpdaterSpec.scala
@@ -6,10 +6,9 @@ import org.scalatest.WordSpec
 import play.api.libs.json._
 import com.evolutiongaming.json.PartialUpdater._
 
-
 class PartialUpdaterSpec extends WordSpec {
   import PartialUpdaterSpec._
-  
+
   implicit val phoneReads: Reads[Phone]                = Json.reads[Phone]
   implicit val phoneUpdater: PartialUpdater[Phone]     = PartialUpdater.updater[Phone]
   implicit val addressUpdater: PartialUpdater[Address] = PartialUpdater.updater[Address]
@@ -52,6 +51,10 @@ class PartialUpdaterSpec extends WordSpec {
     "affect entity's 'phone' if json contains 'phone' property with null" in new Scope {
       (profile updated json"""{"phone": null}""") mustBe profile.copy(phone = None)
     }
+
+    "affect entity's 'type' if json contains 'type' property" in new Scope {
+      (profile updated json"""{"type": "premium"}""") mustBe profile.copy(`type` = Some(ProfileType.Premium))
+    }
   }
 
   trait Scope {
@@ -65,7 +68,9 @@ class PartialUpdaterSpec extends WordSpec {
       alias = Some("alias"),
       phone = Some(Phone(
         area = "area",
-        number = "number")))
+        number = "number")),
+      `type` = Some(ProfileType.Free),
+    )
   }
 }
 

--- a/src/test/scala/com/evolutiongaming/json/model.scala
+++ b/src/test/scala/com/evolutiongaming/json/model.scala
@@ -1,5 +1,41 @@
 package com.evolutiongaming.json
 
+import play.api.libs.json._
+
 case class Phone(area: String, number: String)
 case class Address(city: String, street: String, building: Int)
-case class Profile(@skip id: String, name: String, address: Address, alias: Option[String], phone: Option[Phone])
+case class Profile(
+  @skip id: String,
+  name: String,
+  address: Address,
+  alias: Option[String],
+  phone: Option[Phone],
+  `type`: Option[ProfileType],
+)
+
+sealed abstract case class ProfileType(value: String)
+
+object ProfileType {
+  val Free: ProfileType = new ProfileType("free") {}
+  val Premium: ProfileType = new ProfileType("premium") {}
+
+  def of(code: String): Either[String, ProfileType] = code match {
+    case Free.value => Right(Free)
+    case Premium.value => Right(Premium)
+    case _ => Left(s"Unknown profile type: $code")
+  }
+
+  implicit val JsonFormat: Format[ProfileType] = new Format[ProfileType] {
+    def reads(json: JsValue): JsResult[ProfileType] = {
+      for {
+        str <- json.validate[String]
+        tpe <- ProfileType.of(str) match {
+          case Right(tpe) => JsSuccess(tpe)
+          case Left(err) => JsError(err)
+        }
+      } yield tpe
+    }
+
+    override def writes(o: ProfileType): JsValue = JsString(o.value)
+  }
+}


### PR DESCRIPTION
In `ResultingType#apply` function we don't check for abstract classes, so the function returns `CaseClass`. To correctly handle enums we need `Generic`.