### PR TITLE
Adopt shared Scala CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@e9f3a8d1d95e9ed5b762627a28a1ce93fad45f0a # v6.2.0
+    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@dde27b9bd793d41d5aacf8fb74403c9de5da1146 # v6.3.0
     with:
       # TODO no sbt-version-policy in this repo, so binary compatibility was never checked
       version_policy_check: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,7 @@ on:
 
 jobs:
   test:
-    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@v6
-    secrets: inherit
+    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@2a389d2a5f4b093e72f738464bd7472bd0c3b4b8 # v6
     with:
       # TODO no sbt-version-policy in this repo, so binary compatibility was never checked
       version_policy_check: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,36 +7,10 @@ on:
 
 jobs:
   test:
-
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        scala:
-          - 2.13.18
-          - 3.3.8
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: coursier/cache-action@v6
-
-      - name: setup Java 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'sbt'
-
-      - name: setup SBT
-        uses: sbt/setup-sbt@v1
-
-      - name: build ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} clean coverage test
-
-      - name: test coverage
-        if: success()
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: Scala ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} coverageReport coveralls
+    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@v6
+    secrets: inherit
+    with:
+      # TODO no sbt-version-policy in this repo, so binary compatibility was never checked
+      version_policy_check: false
+      # TODO no sbt-scalafmt in this repo, so formatting was never checked
+      scalafmt_check: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@2a389d2a5f4b093e72f738464bd7472bd0c3b4b8 # v6
+    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@e9f3a8d1d95e9ed5b762627a28a1ce93fad45f0a # v6.2.0
     with:
       # TODO no sbt-version-policy in this repo, so binary compatibility was never checked
       version_policy_check: false

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,5 @@ addSbtPlugin("com.evolution" % "sbt-artifactory-plugin" % "0.1.2")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.15")
 
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,5 +2,4 @@ addSbtPlugin("com.evolution" % "sbt-artifactory-plugin" % "0.1.2")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")
 
-
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")


### PR DESCRIPTION
Replaces the hand-written ci.yml with a call to the shared workflow, so tests, coverage, binary compatibility, formatting and scaladoc are configured centrally. Binary compatibility is switched off explicitly because the repo has no sbt-version-policy; it was never enforced. Same for scalafmt.

Checks now run as explicit sbt tasks rather than through the `check` alias, and checkout is unshallow so versionPolicyCheck has a previous version to compare against.

Part of evolution-gaming/scala-github-actions#5